### PR TITLE
Adopt Material 3 styling for AppShop UI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,8 +39,6 @@ dependencies {
     implementation 'com.google.android.material:material:1.11.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.recyclerview:recyclerview:1.3.2'
-    implementation 'androidx.cardview:cardview:1.0.0'
-
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.2'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2' // <-- добавил
 

--- a/app/src/main/java/com/example/appshop/MainActivity.kt
+++ b/app/src/main/java/com/example/appshop/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.appshop.R
 import com.example.appshop.data.model.Product
 import com.example.appshop.data.repository.Repository
 import com.example.appshop.databinding.ActivityMainBinding
@@ -26,6 +27,18 @@ class MainActivity : AppCompatActivity() {
 
         repo = Repository(applicationContext)
 
+        setSupportActionBar(binding.toolbar)
+        binding.bottomNavigation.selectedItemId = R.id.menu_home
+        binding.bottomNavigation.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.menu_cart -> {
+                    startActivity(Intent(this, CartActivity::class.java))
+                    false
+                }
+                else -> true
+            }
+        }
+
         binding.recyclerProducts.layoutManager = LinearLayoutManager(this)
 
         binding.fabCart.setOnClickListener {
@@ -33,6 +46,11 @@ class MainActivity : AppCompatActivity() {
         }
 
         loadProducts()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        binding.bottomNavigation.selectedItemId = R.id.menu_home
     }
 
     private fun loadProducts() {

--- a/app/src/main/java/com/example/appshop/ui/activities/CartActivity.kt
+++ b/app/src/main/java/com/example/appshop/ui/activities/CartActivity.kt
@@ -24,6 +24,12 @@ class CartActivity : AppCompatActivity() {
         setContentView(binding.root)
         repo = Repository(applicationContext)
 
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.toolbar.setNavigationOnClickListener {
+            onBackPressedDispatcher.onBackPressed()
+        }
+
         adapter = CartAdapter(mutableListOf(),
             onQuantityChange = { item ->
                 lifecycleScope.launch {

--- a/app/src/main/java/com/example/appshop/ui/activities/ItemActivity.kt
+++ b/app/src/main/java/com/example/appshop/ui/activities/ItemActivity.kt
@@ -25,6 +25,12 @@ class ItemActivity : AppCompatActivity() {
         setContentView(binding.root)
         repo = Repository(applicationContext)
 
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.toolbar.setNavigationOnClickListener {
+            onBackPressedDispatcher.onBackPressed()
+        }
+
         product = extractProduct()
         product?.let { p ->
             binding.tvDetailTitle.text = p.title

--- a/app/src/main/res/color/nav_item_colors.xml
+++ b/app/src/main/res/color/nav_item_colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/iconActive" android:state_checked="true" />
+    <item android:color="@color/iconInactive" android:state_checked="false" />
+</selector>

--- a/app/src/main/res/drawable/ic_add.xml
+++ b/app/src/main/res/drawable/ic_add.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,5h2v6h6v2h-6v6h-2v-6H5v-2h6z" />
+</vector>

--- a/app/src/main/res/drawable/ic_category_accessories.xml
+++ b/app/src/main/res/drawable/ic_category_accessories.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,9V7c0,-2.2 1.8,-4 4,-4s4,1.8 4,4v2h3c0.6,0 1,0.4 1,1v10c0,0.6 -0.4,1 -1,1H4c-0.6,0 -1,-0.4 -1,-1V10c0,-0.6 0.4,-1 1,-1h3zm2,0h6V7c0,-1.1 -0.9,-2 -2,-2h-2c-1.1,0 -2,0.9 -2,2v2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_category_clothing.xml
+++ b/app/src/main/res/drawable/ic_category_clothing.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M8,4l2,2h4l2,-2 4,3 -1.5,2.3L18,8.5V20H6V8.5L5.5,9.3 4,7z" />
+</vector>

--- a/app/src/main/res/drawable/ic_category_electronics.xml
+++ b/app/src/main/res/drawable/ic_category_electronics.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,5h10c1.1,0 2,0.9 2,2v10c0,1.1 -0.9,2 -2,2H7c-1.1,0 -2,-0.9 -2,-2V7c0,-1.1 0.9,-2 2,-2zm3,4v6h4V9H10z" />
+    <path android:fillColor="@android:color/white" android:pathData="M5,2h2v3H5z" />
+    <path android:fillColor="@android:color/white" android:pathData="M9,2h2v3H9z" />
+    <path android:fillColor="@android:color/white" android:pathData="M13,2h2v3h-2z" />
+    <path android:fillColor="@android:color/white" android:pathData="M17,2h2v3h-2z" />
+    <path android:fillColor="@android:color/white" android:pathData="M5,19h2v3H5z" />
+    <path android:fillColor="@android:color/white" android:pathData="M9,19h2v3H9z" />
+    <path android:fillColor="@android:color/white" android:pathData="M13,19h2v3h-2z" />
+    <path android:fillColor="@android:color/white" android:pathData="M17,19h2v3h-2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_category_shoes.xml
+++ b/app/src/main/res/drawable/ic_category_shoes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,15h9l2,-3h5l2,5v3H3z" />
+</vector>

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM9,9h2v8H9zm4,0h2v8h-2zM15.5,4l-1,-1h-5l-1,1H5v2h14V4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_favorite_outline.xml
+++ b/app/src/main/res/drawable/ic_favorite_outline.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M0,0h24v24H0z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:fillType="evenOdd"
+        android:pathData="M12,21l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.18zM7.5,5C5.57,5 4,6.57 4,8.5c0,2.54 2.61,5.23 8,9.54 5.39,-4.32 8,-7 8,-9.54 0,-1.93 -1.57,-3.5 -3.5,-3.5 -1.54,0 -3.04,0.99 -3.57,2.36h-1.87C10.54,5.99 9.04,5 7.5,5z" />
+</vector>

--- a/app/src/main/res/drawable/ic_nav_cart.xml
+++ b/app/src/main/res/drawable/ic_nav_cart.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,20a2,2 0 1,0 0,4 2,2 0 1,0 0,-4zm10,0a2,2 0 1,0 0,4 2,2 0 1,0 0,-4zM6.2,6l-0.9,-2H2v2h2l3.2,9.2c0.2,0.6 0.8,0.8 1.3,0.8H19v-2H8.4l-0.4,-1.2h10.3c0.7,0 1.3,-0.4 1.5,-1l2,-6H6.2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_nav_catalog.xml
+++ b/app/src/main/res/drawable/ic_nav_catalog.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M5,5h4v4H5z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,6h8v2h-8z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M5,11h4v4H5z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,12h8v2h-8z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M5,17h4v4H5z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,18h8v2h-8z" />
+</vector>

--- a/app/src/main/res/drawable/ic_nav_favorites.xml
+++ b/app/src/main/res/drawable/ic_nav_favorites.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,21.35l-1.45-1.32C5.4,15.36 2,12.28 2,8.5 2,6 4,4 6.5,4c1.74,0 3.41,1.01 4.5,2.09C12.09,5.01 13.76,4 15.5,4 18,4 20,6 20,8.5c0,3.78-3.4,6.86-8.55,11.53z" />
+</vector>

--- a/app/src/main/res/drawable/ic_nav_home.xml
+++ b/app/src/main/res/drawable/ic_nav_home.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,3L3,11h2v10h6v-6h2v6h6V11h2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_nav_profile.xml
+++ b/app/src/main/res/drawable/ic_nav_profile.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,12a4,4 0 1,0 0,-8 4,4 0 0,0 0,8z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M4,20c0,-3.3 3.6,-6 8,-6s8,2.7 8,6v2H4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_remove.xml
+++ b/app/src/main/res/drawable/ic_remove.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M5,11h14v2H5z" />
+</vector>

--- a/app/src/main/res/layout/activity_cart.xml
+++ b/app/src/main/res/layout/activity_cart.xml
@@ -1,28 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:padding="12dp">
+    android:background="@color/colorBackground"
+    android:paddingBottom="16dp"
+    tools:context=".ui.activities.CartActivity">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="?attr/toolbarStyle"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/cart_title"
+        app:titleCentered="false" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerCart"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_weight="1" />
+        android:clipToPadding="false"
+        android:paddingHorizontal="16dp"
+        android:paddingTop="12dp"
+        app:layout_constraintBottom_toTopOf="@id/tvTotal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        tools:listitem="@layout/item_cart" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/tvTotal"
-        android:layout_width="match_parent"
+        style="@style/TextAppearance.AppShop.Total"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:paddingTop="8dp"
-        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-        android:textStyle="bold" />
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/recyclerCart"
+        tools:text="Total: 0 ₽" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/btnCheckout"
-        android:layout_width="match_parent"
+        style="@style/AppButtonStyle"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:text="@string/checkout" />
-</LinearLayout>
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="12dp"
+        android:text="@string/checkout"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvTotal" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_item.xml
+++ b/app/src/main/res/layout/activity_item.xml
@@ -1,49 +1,81 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="12dp">
+    android:background="@color/colorBackground"
+    tools:context=".ui.activities.ItemActivity">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="?attr/toolbarStyle"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/item_details_title"
+        app:titleCentered="false" />
 
-        <ImageView
-            android:id="@+id/imgDetail"
-            android:layout_width="match_parent"
-            android:layout_height="220dp"
-            android:scaleType="centerCrop"
-            android:src="@drawable/ic_launcher_foreground" />
+    <ScrollView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        android:paddingHorizontal="16dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar">
 
-        <TextView
-            android:id="@+id/tvDetailTitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:textSize="20sp"
-            android:textStyle="bold" />
-
-        <TextView
-            android:id="@+id/tvDetailPrice"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            android:textSize="18sp" />
-
-        <TextView
-            android:id="@+id/tvDetailDesc"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:textSize="14sp" />
+            android:orientation="vertical">
 
-        <Button
-            android:id="@+id/btnAddToCart"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            android:text="@string/add_to_cart" />
+            <com.google.android.material.imageview.ShapeableImageView
+                android:id="@+id/imgDetail"
+                android:layout_width="match_parent"
+                android:layout_height="220dp"
+                android:scaleType="centerCrop"
+                app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.AppShop.Image"
+                tools:src="@drawable/ic_category_clothing" />
 
-    </LinearLayout>
-</ScrollView>
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/tvDetailTitle"
+                style="@style/TextAppearance.AppShop.DetailTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                tools:text="Stylish Jacket" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/tvDetailPrice"
+                style="@style/TextAppearance.AppShop.ProductPrice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                tools:text="4500 ₽" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/tvDetailDesc"
+                style="@style/TextAppearance.AppShop.Body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                tools:text="Description goes here." />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnAddToCart"
+                style="@style/AppButtonStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/add_to_cart" />
+
+        </LinearLayout>
+    </ScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,38 +1,209 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/colorBackground"
+    tools:context=".MainActivity">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
+        style="?attr/toolbarStyle"
         android:layout_width="0dp"
         android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        app:title="@string/app_name"
-        app:titleTextColor="@android:color/white"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/app_name"
+        app:titleCentered="false" />
+
+    <LinearLayout
+        android:id="@+id/categoriesContainer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tvCategoriesTitle"
+            style="@style/TextAppearance.AppShop.SectionTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/main_categories_title" />
+
+        <HorizontalScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:overScrollMode="never"
+            android:scrollbars="none">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingEnd="16dp">
+
+                <com.google.android.material.card.MaterialCardView
+                    style="@style/Widget.AppShop.CategoryCard"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="12dp">
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal"
+                        android:paddingHorizontal="16dp"
+                        android:paddingVertical="12dp">
+
+                        <ImageView
+                            android:layout_width="32dp"
+                            android:layout_height="32dp"
+                            android:contentDescription="@string/category_clothing"
+                            android:tint="@color/category_clothing"
+                            app:srcCompat="@drawable/ic_category_clothing" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="12dp"
+                            android:text="@string/category_clothing"
+                            style="@style/TextAppearance.AppShop.CategoryLabel" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    style="@style/Widget.AppShop.CategoryCard"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="12dp">
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal"
+                        android:paddingHorizontal="16dp"
+                        android:paddingVertical="12dp">
+
+                        <ImageView
+                            android:layout_width="32dp"
+                            android:layout_height="32dp"
+                            android:contentDescription="@string/category_shoes"
+                            android:tint="@color/category_shoes"
+                            app:srcCompat="@drawable/ic_category_shoes" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="12dp"
+                            android:text="@string/category_shoes"
+                            style="@style/TextAppearance.AppShop.CategoryLabel" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    style="@style/Widget.AppShop.CategoryCard"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="12dp">
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal"
+                        android:paddingHorizontal="16dp"
+                        android:paddingVertical="12dp">
+
+                        <ImageView
+                            android:layout_width="32dp"
+                            android:layout_height="32dp"
+                            android:contentDescription="@string/category_accessories"
+                            android:tint="@color/category_accessories"
+                            app:srcCompat="@drawable/ic_category_accessories" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="12dp"
+                            android:text="@string/category_accessories"
+                            style="@style/TextAppearance.AppShop.CategoryLabel" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    style="@style/Widget.AppShop.CategoryCard"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content">
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal"
+                        android:paddingHorizontal="16dp"
+                        android:paddingVertical="12dp">
+
+                        <ImageView
+                            android:layout_width="32dp"
+                            android:layout_height="32dp"
+                            android:contentDescription="@string/category_electronics"
+                            android:tint="@color/category_electronics"
+                            app:srcCompat="@drawable/ic_category_electronics" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="12dp"
+                            android:text="@string/category_electronics"
+                            style="@style/TextAppearance.AppShop.CategoryLabel" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+            </LinearLayout>
+        </HorizontalScrollView>
+    </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerProducts"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:padding="8dp"
+        android:clipToPadding="false"
+        android:paddingHorizontal="16dp"
+        android:paddingBottom="16dp"
+        app:layout_constraintBottom_toTopOf="@id/bottomNavigation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/categoriesContainer"
+        tools:listitem="@layout/item_product" />
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottomNavigation"
+        style="@style/AppBottomNavStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+        app:menu="@menu/menu_bottom_navigation" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fabCart"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:contentDescription="@string/view_cart"
         android:layout_margin="16dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:contentDescription="@string/view_cart"
+        app:layout_constraintBottom_toTopOf="@id/bottomNavigation"
         app:layout_constraintEnd_toEndOf="parent"
-        app:srcCompat="@android:drawable/ic_menu_view" />
+        app:srcCompat="@drawable/ic_nav_cart" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_cart.xml
+++ b/app/src/main/res/layout/item_cart.xml
@@ -1,88 +1,94 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="6dp"
-    app:cardCornerRadius="8dp"
-    app:cardUseCompatPadding="true">
+    android:layout_marginVertical="8dp"
+    style="@style/Widget.AppShop.ProductCard">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:gravity="center_vertical"
         android:orientation="horizontal"
-        android:padding="12dp">
+        android:padding="16dp">
 
-        <ImageView
+        <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/imgCart"
-            android:layout_width="80dp"
-            android:layout_height="80dp"
+            android:layout_width="88dp"
+            android:layout_height="88dp"
             android:contentDescription="@string/cart_item_image_content_description"
             android:scaleType="centerCrop"
-            android:src="@drawable/ic_launcher_foreground" />
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.AppShop.Image"
+            tools:src="@drawable/ic_category_clothing" />
 
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
+            android:layout_marginStart="16dp"
             android:layout_weight="1"
             android:orientation="vertical">
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/tvCartTitle"
+                style="@style/TextAppearance.AppShop.ProductTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-                android:textStyle="bold" />
+                tools:text="Product name" />
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/tvCartPrice"
+                style="@style/TextAppearance.AppShop.ProductPrice"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
-                android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+                tools:text="4500 ₽" />
 
             <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
+                android:layout_marginTop="12dp"
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
 
-                <ImageButton
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/btnMinus"
-                    style="@style/Widget.MaterialComponents.Button.TextButton.Icon"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:background="?attr/selectableItemBackgroundBorderless"
+                    style="@style/Widget.Material3.Button.TonalIcon"
                     android:contentDescription="@string/cart_decrease_quantity"
-                    android:src="@android:drawable/ic_media_previous" />
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:icon="@drawable/ic_remove"
+                    app:iconTint="@color/colorPrimary" />
 
-                <TextView
+                <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/tvQuantity"
+                    style="@style/TextAppearance.Material3.TitleMedium"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="12dp"
-                    android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+                    android:layout_marginHorizontal="16dp"
+                    tools:text="1" />
 
-                <ImageButton
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/btnPlus"
-                    style="@style/Widget.MaterialComponents.Button.TextButton.Icon"
+                    style="@style/Widget.Material3.Button.TonalIcon"
+                    android:contentDescription="@string/cart_increase_quantity"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:background="?attr/selectableItemBackgroundBorderless"
-                    android:contentDescription="@string/cart_increase_quantity"
-                    android:src="@android:drawable/ic_media_next" />
+                    app:icon="@drawable/ic_add"
+                    app:iconTint="@color/colorPrimary" />
             </LinearLayout>
         </LinearLayout>
 
-        <ImageButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btnRemove"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_marginStart="8dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
+            style="@style/Widget.Material3.Button.OutlinedIcon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
             android:contentDescription="@string/cart_remove_item"
-            android:src="@android:drawable/ic_menu_delete" />
+            app:icon="@drawable/ic_delete"
+            app:iconTint="@color/colorOnSurfaceVariant" />
+
     </LinearLayout>
-</androidx.cardview.widget.CardView>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_product.xml
+++ b/app/src/main/res/layout/item_product.xml
@@ -1,55 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    card_view:cardCornerRadius="8dp"
-    android:layout_margin="6dp"
-    android:elevation="4dp">
+    android:layout_marginVertical="8dp"
+    style="@style/Widget.AppShop.ProductCard">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="8dp"
-        android:orientation="horizontal">
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:padding="12dp">
 
-        <ImageView
+        <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/imgProduct"
-            android:layout_width="80dp"
-            android:layout_height="80dp"
+            android:layout_width="88dp"
+            android:layout_height="88dp"
             android:scaleType="centerCrop"
-            android:src="@drawable/ic_launcher_foreground" />
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.AppShop.Image"
+            tools:src="@drawable/ic_category_clothing" />
 
         <LinearLayout
-            android:orientation="vertical"
-            android:layout_marginStart="8dp"
             android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
             android:layout_weight="1"
-            android:layout_height="wrap_content">
+            android:orientation="vertical">
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/tvTitle"
-                android:textStyle="bold"
-                android:textSize="16sp"
+                style="@style/TextAppearance.AppShop.ProductTitle"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content"
+                tools:text="Stylish Jacket" />
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/tvPrice"
-                android:layout_marginTop="6dp"
-                android:textSize="14sp"
+                style="@style/TextAppearance.AppShop.ProductPrice"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                tools:text="4500 ₽" />
 
         </LinearLayout>
 
-        <ImageButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btnFavorite"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:src="@android:drawable/btn_star_big_off"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="favorite"/>
+            style="@style/Widget.Material3.Button.Icon"
+            android:contentDescription="@string/product_favorite"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_favorite_outline"
+            app:iconTint="@color/iconInactive"
+            app:backgroundTint="@android:color/transparent"
+            app:rippleColor="@color/iconActive" />
+
     </LinearLayout>
 
-</androidx.cardview.widget.CardView>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/menu/menu_bottom_navigation.xml
+++ b/app/src/main/res/menu/menu_bottom_navigation.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/menu_home"
+        android:icon="@drawable/ic_nav_home"
+        android:title="@string/menu_home" />
+    <item
+        android:id="@+id/menu_catalog"
+        android:icon="@drawable/ic_nav_catalog"
+        android:title="@string/menu_catalog" />
+    <item
+        android:id="@+id/menu_favorites"
+        android:icon="@drawable/ic_nav_favorites"
+        android:title="@string/menu_favorites" />
+    <item
+        android:id="@+id/menu_cart"
+        android:icon="@drawable/ic_nav_cart"
+        android:title="@string/menu_cart" />
+    <item
+        android:id="@+id/menu_profile"
+        android:icon="@drawable/ic_nav_profile"
+        android:title="@string/menu_profile" />
+</menu>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,22 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Основные акцентные цвета -->
-    <color name="colorPrimary">#2196F3</color> <!-- синий -->
-    <color name="colorOnPrimary">#FFFFFF</color> <!-- текст/иконки поверх синего -->
+    <color name="colorPrimary">#2196F3</color>
+    <color name="colorOnPrimary">#FFFFFF</color>
 
-    <color name="colorSecondary">#FF9800</color> <!-- оранжевый акцент -->
+    <color name="colorSecondary">#FF9800</color>
     <color name="colorOnSecondary">#FFFFFF</color>
 
-    <!-- Фон и поверхности -->
-    <color name="colorBackground">#FFFFFF</color>
+    <!-- Поверхности -->
+    <color name="colorBackground">#F5F7FA</color>
     <color name="colorSurface">#FFFFFF</color>
-    <color name="colorOnBackground">#000000</color>
-    <color name="colorOnSurface">#000000</color>
+    <color name="colorOnBackground">#1C1B1F</color>
+    <color name="colorOnSurface">#1C1B1F</color>
+    <color name="colorOnSurfaceVariant">#5F6368</color>
+    <color name="colorOutline">#E0E3EB</color>
 
-    <!-- Дополнительно для текста/иконок -->
-    <color name="textPrimary">#212121</color>
+    <!-- Дополнительные оттенки -->
     <color name="textSecondary">#757575</color>
     <color name="iconInactive">#808080</color>
     <color name="iconActive">#2196F3</color>
+    <color name="colorPriceHighlight">#1E88E5</color>
+
+    <!-- Цвета категорий -->
+    <color name="category_clothing">#1E88E5</color>
+    <color name="category_shoes">#8E24AA</color>
+    <color name="category_accessories">#FB8C00</color>
+    <color name="category_electronics">#009688</color>
+
+    <color name="category_card_stroke">#E3E7EF</color>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,17 @@
     <string name="cart_decrease_quantity">Decrease quantity</string>
     <string name="cart_increase_quantity">Increase quantity</string>
     <string name="cart_remove_item">Remove item</string>
+    <string name="cart_title">Cart</string>
+    <string name="item_details_title">Product details</string>
+    <string name="main_categories_title">Categories</string>
+    <string name="category_clothing">Clothing</string>
+    <string name="category_shoes">Shoes</string>
+    <string name="category_accessories">Accessories</string>
+    <string name="category_electronics">Electronics</string>
+    <string name="product_favorite">Add to favorites</string>
+    <string name="menu_home">Home</string>
+    <string name="menu_catalog">Catalog</string>
+    <string name="menu_favorites">Favorites</string>
+    <string name="menu_cart">Cart</string>
+    <string name="menu_profile">Profile</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Widget.AppShop.BaseCard" parent="Widget.Material3.CardView.Elevated">
+        <item name="cardCornerRadius">12dp</item>
+        <item name="cardBackgroundColor">@color/colorSurface</item>
+        <item name="strokeColor">@android:color/transparent</item>
+    </style>
+
+    <style name="Widget.AppShop.ProductCard" parent="Widget.AppShop.BaseCard">
+        <item name="cardElevation">3dp</item>
+        <item name="shapeAppearance">@style/ShapeAppearance.Material3.Corner.Medium</item>
+    </style>
+
+    <style name="Widget.AppShop.CategoryCard" parent="Widget.Material3.CardView.Outlined">
+        <item name="cardCornerRadius">16dp</item>
+        <item name="cardBackgroundColor">@color/colorSurface</item>
+        <item name="strokeColor">@color/category_card_stroke</item>
+        <item name="strokeWidth">1dp</item>
+    </style>
+
+    <style name="TextAppearance.AppShop.SectionTitle" parent="TextAppearance.Material3.TitleMedium">
+        <item name="android:textColor">@color/colorOnSurface</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextAppearance.AppShop.CategoryLabel" parent="TextAppearance.Material3.BodyMedium">
+        <item name="android:textColor">@color/colorOnSurface</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextAppearance.AppShop.ProductTitle" parent="TextAppearance.Material3.TitleSmall">
+        <item name="android:textColor">@color/colorOnSurface</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextAppearance.AppShop.ProductPrice" parent="TextAppearance.Material3.TitleSmall">
+        <item name="android:textColor">@color/colorPriceHighlight</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextAppearance.AppShop.Body" parent="TextAppearance.Material3.BodyMedium">
+        <item name="android:textColor">@color/colorOnSurfaceVariant</item>
+    </style>
+
+    <style name="ShapeAppearanceOverlay.AppShop.Image" parent="@style/ShapeAppearanceOverlay.Material3.MediumComponent">
+        <item name="cornerSize">16dp</item>
+    </style>
+
+    <style name="TextAppearance.AppShop.DetailTitle" parent="TextAppearance.Material3.TitleLarge">
+        <item name="android:textColor">@color/colorOnSurface</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextAppearance.AppShop.Total" parent="TextAppearance.Material3.TitleMedium">
+        <item name="android:textColor">@color/colorOnSurface</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,7 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Базовая тема приложения -->
     <style name="Theme.AppShop" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <!-- Цвета -->
+        <!-- Цветовая палитра -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorOnPrimary">@color/colorOnPrimary</item>
         <item name="colorSecondary">@color/colorSecondary</item>
@@ -10,31 +10,45 @@
         <item name="android:colorBackground">@color/colorBackground</item>
         <item name="colorSurface">@color/colorSurface</item>
         <item name="colorOnSurface">@color/colorOnSurface</item>
+        <item name="colorOnSurfaceVariant">@color/colorOnSurfaceVariant</item>
+        <item name="colorOutline">@color/colorOutline</item>
 
-        <!-- Статус-бар -->
-        <item name="android:statusBarColor">@color/colorPrimary</item>
+        <!-- Системные элементы -->
+        <item name="android:statusBarColor">@color/colorSurface</item>
         <item name="android:windowLightStatusBar">true</item>
+        <item name="android:navigationBarColor">@color/colorSurface</item>
 
-        <!-- Toolbar -->
+        <!-- Компоненты -->
         <item name="toolbarStyle">@style/AppToolbarStyle</item>
-
-        <!-- BottomNavigation -->
         <item name="bottomNavigationStyle">@style/AppBottomNavStyle</item>
+        <item name="materialButtonStyle">@style/AppButtonStyle</item>
+        <item name="materialCardViewStyle">@style/Widget.AppShop.BaseCard</item>
+        <item name="floatingActionButtonStyle">@style/AppFabStyle</item>
     </style>
 
     <!-- Стиль для Toolbar -->
-    <style name="AppToolbarStyle" parent="Widget.MaterialComponents.Toolbar.Primary">
+    <style name="AppToolbarStyle" parent="Widget.Material3.Toolbar">
         <item name="android:background">@color/colorSurface</item>
-        <item name="titleTextColor">@color/textPrimary</item>
+        <item name="titleTextColor">@color/colorOnSurface</item>
         <item name="subtitleTextColor">@color/textSecondary</item>
+        <item name="navigationIconTint">@color/colorOnSurface</item>
         <item name="android:elevation">4dp</item>
     </style>
 
     <!-- Стиль для BottomNavigation -->
-    <style name="AppBottomNavStyle" parent="Widget.MaterialComponents.BottomNavigationView.Colored">
+    <style name="AppBottomNavStyle" parent="Widget.Material3.BottomNavigationView">
         <item name="itemIconTint">@color/nav_item_colors</item>
         <item name="itemTextColor">@color/nav_item_colors</item>
         <item name="android:background">@color/colorSurface</item>
+        <item name="android:elevation">8dp</item>
+    </style>
+
+    <style name="AppButtonStyle" parent="Widget.Material3.Button">
+        <item name="android:textAllCaps">false</item>
+    </style>
+
+    <style name="AppFabStyle" parent="Widget.Material3.FloatingActionButton">
+        <item name="android:tint">@color/colorOnPrimary</item>
     </style>
 </resources>
 


### PR DESCRIPTION
## Summary
- refresh the main, cart, and item layouts with Material 3 toolbars, category chips, cards, and a styled bottom navigation
- centralize Material 3 color palette, typography, and component styles in the theme and styles resources
- wire activities to the new top app bars and navigation while adding vector icon assets and bottom navigation menu resources

## Testing
- `./gradlew assembleDebug` *(fails: Unable to download Gradle distribution because the proxy returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68db6bd90300832eb2e0a87549eae201